### PR TITLE
Add twitter endpoint to backend.

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,6 @@
 venv/
 petition_files/**
 gofundme_files/**
+twitter_files/**
+Lib/
+Scripts/

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -3,6 +3,7 @@ import flask
 # API Endpoint Imports
 import petition_count as pc
 import gofundme as gfm
+import twitter_count as twt
 
 app = flask.Flask(__name__)
 
@@ -17,5 +18,9 @@ def petition_count():
 @app.route("/gofundme")
 def gofundme():
 	return gfm.fetch_gofundme()
+
+@app.route("/twitter_count")
+def twitter_count():
+	return twt.fetch_twitter_count()
 
 app.run()

--- a/backend/twitter_count.py
+++ b/backend/twitter_count.py
@@ -1,0 +1,41 @@
+import datetime
+import os
+import requests
+import utils.file_format as ff
+import json
+from flask import jsonify
+
+def fetch_twitter_count():
+    cur_date_time = datetime.datetime.now()
+    cur_hour_minute = cur_date_time.strftime("%Y-%m-%d %H-%M")
+    filename = ff.format_filename(cur_hour_minute)
+    path = ff.format_path(filename, "twitter_files")
+    if os.path.isfile(path): 
+        with open(path, "r") as f:
+            content = jsonify(json.load(f))
+    else:
+        res = make_request()
+        count = get_count(res)
+        content = {"last_7_days_count" : count }
+        with open(path, "w") as f:
+            json.dump(content, f)
+        content = jsonify(content)
+    return content
+
+def make_request():
+    token = os.getenv('TWT_TOKEN')
+    headers = {"Authorization": "Bearer {}".format(token)}
+
+    # For this endpoint we need Academic Research or Enterprise access.
+    #endpoint = "https://api.twitter.com/2/tweets/counts/all"
+    #params = {'query': '#SaveWarriorNun','granularity': 'day', 'start_time': '2022-12-13T00:00:00Z'}
+    
+    # Free access endpoint, gives count for the last 7 days only.
+    endpoint = "https://api.twitter.com/2/tweets/counts/recent"
+    params = {'query': '#SaveWarriorNun','granularity': 'day'}
+
+    x = requests.request("GET", endpoint, headers = headers, params = params)
+    return x.json()
+
+def get_count(content):
+    return sum([day_data['tweet_count'] for day_data in content['data']])


### PR DESCRIPTION
- Twitter endpoint returns tweets count using #SaveWarriorNun from the last 7 days.
- To get the full count, we would need Academic Research or Enterprise access to the API.